### PR TITLE
Fix headless editor test for Node 20+

### DIFF
--- a/resources/js/wysiwyg/lexical/headless/__tests__/unit/LexicalHeadlessEditor.test.ts
+++ b/resources/js/wysiwyg/lexical/headless/__tests__/unit/LexicalHeadlessEditor.test.ts
@@ -62,7 +62,8 @@ describe('LexicalHeadlessEditor', () => {
   it('should be headless environment', async () => {
     expect(typeof window === 'undefined').toBe(true);
     expect(typeof document === 'undefined').toBe(true);
-    expect(typeof navigator === 'undefined').toBe(true);
+    // "navigator" may be globally defined in newer Node versions so we
+    // avoid strict expectations on its existence.
   });
 
   it('can update editor', async () => {


### PR DESCRIPTION
## Summary
- adapt the `LexicalHeadlessEditor` test to handle global navigator in Node >=20

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fb84e89f8832f82dc80419e1c33a2