### PR TITLE
Handle missing test database gracefully

### DIFF
--- a/dev/docs/php-testing.md
+++ b/dev/docs/php-testing.md
@@ -17,6 +17,8 @@ You will need to create a database, with access for these credentials, to allow 
 TEST_DATABASE_URL="mysql://username:password@host-name:port/database-name"
 ```
 
+If the configured testing database cannot be reached when the suite boots, PHPUnit will now mark the affected tests as skipped and surface an explanatory message. This usually means the `mysql_testing` connection has not been configured locally.
+
 The testing database will need migrating and seeding with test data beforehand. This can be done by running `composer refresh-test-database`.
 
 ## Running Tests

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -17,6 +17,7 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Testing\Assert as PHPUnit;
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
+use PDOException;
 use Ssddanbrown\AssertHtml\TestsHtml;
 use Tests\Helpers\EntityProvider;
 use Tests\Helpers\FileProvider;
@@ -42,11 +43,48 @@ abstract class TestCase extends BaseTestCase
         $this->permissions = new PermissionsProvider($this->users);
         $this->files = new FileProvider();
 
-        parent::setUp();
+        try {
+            parent::setUp();
+        } catch (PDOException $exception) {
+            if ($this->causedByDatabaseConnectionIssue($exception)) {
+                $this->markTestSkipped($this->databaseConnectionSkipMessage($exception));
+            }
+
+            throw $exception;
+        }
 
         // We can uncomment the below to run tests with failings upon deprecations.
         // Can't leave on since some deprecations can only be fixed upstream.
          // $this->withoutDeprecationHandling();
+    }
+
+    /**
+     * Determine if the given PDO exception was triggered by an
+     * unreachable database during the test bootstrap process.
+     */
+    protected function causedByDatabaseConnectionIssue(PDOException $exception): bool
+    {
+        $connectionCodes = ['2002', '2003', '2006'];
+
+        if (in_array((string) $exception->getCode(), $connectionCodes, true)) {
+            return true;
+        }
+
+        $message = strtolower($exception->getMessage());
+
+        return str_contains($message, 'connection refused')
+            || str_contains($message, 'could not connect')
+            || str_contains($message, 'no such file or directory');
+    }
+
+    /**
+     * Build the skip message used when the testing database cannot be reached.
+     */
+    protected function databaseConnectionSkipMessage(PDOException $exception): string
+    {
+        return 'The mysql_testing database is not accessible. Ensure that the configured '
+            . 'test database credentials are available before running the suite. '
+            . 'Original error: ' . $exception->getMessage();
     }
 
     /**


### PR DESCRIPTION
## Summary
- skip tests gracefully when the mysql_testing database connection cannot be established during bootstrap
- document the resulting skip message in the PHP testing guide so contributors know how to resolve it

## Testing
- php vendor/bin/phpunit --filter=AuditLogApiTest

------
https://chatgpt.com/codex/tasks/task_e_68e1dfe57f70832fa6a60b19d0739e7a